### PR TITLE
Chronicler Retrofill — Add Forensic Backfill Log (v0.1)

### DIFF
--- a/99_LOGS/forensic_backfill_log.md
+++ b/99_LOGS/forensic_backfill_log.md
@@ -1,0 +1,45 @@
+---
+project: Career Intelligence Space
+type: backlog_log
+status: in-progress
+tags: [CIS, Chronicler, ForensicBackfill]
+updated: 2025-09-24
+version: v0.1
+owner: John Wade
+---
+
+# Forensic Backfill Log
+
+This log tracks artifacts that exist in the repo but still require **structural wrapping** (frontmatter, Promotion Notice, Chronicle links, Exchange Blocks). It functions as the audit backlog for the Chronicler role.
+
+---
+
+## Artifact Backlog (Initial Sweep)
+
+| artifact_title         | repo_path                                                                 | commit_SHA | status_detected | missing_structures                  | priority |
+|------------------------|---------------------------------------------------------------------------|------------|-----------------|-------------------------------------|----------|
+| SmartBuild Comp Brief  | 02_TEMPLATES/briefs/20250917_smartbuild_senior_bmt_comp_brief.md          | 85181ba    | matured         | Promotion Notice, Chronicle link    | High     |
+| BACnet Intel           | intel/2025-09-19-bacnet-intel.md                                          | cf69b81    | matured         | Promotion Notice, Chronicle link    | High     |
+| SYNC-COMPARE Export    | 99_LOGS/sync_compare_2025-09-23_transcript-export.md                      | 35ba068    | draft           | Frontmatter, Promotion Notice       | Medium   |
+| Chronicle Newsletter   | 08_CHRONICLE/2025-09-21_chronicler-newsletter-v1.0.md                     | fe16f31    | published       | Promotion Notice                    | Medium   |
+| LLM Protocol Schema    | 10_LLM_STREAMS/2025-09-23_Dual-Prompt_Protocol_and_Exchange_Block_Schema_Development.md | b94aaa3    | in-review       | Chronicle link, Promotion Notice    | Medium   |
+
+---
+
+## Notes
+- **Artifacts = content** (Chronicles, logs, intel briefs, templates, RFCs).
+- **Structures = wrappers** (frontmatter, Promotion Notices, Chronicle back-links, Exchange Blocks).
+- Backfill means: systematically identify artifacts → ensure all required structures exist → update repo with Promotion Notices and Chronicle references.
+
+---
+
+## Next Actions
+1. Confirm and expand backlog by sweeping:
+   - `/08_CHRONICLE`
+   - `/10_LLM_STREAMS`
+   - `/intel`
+   - `/99_LOGS`
+   - `/02_TEMPLATES`
+2. Add missing artifacts to this log.
+3. Prioritize High > Medium > Low for retrofill work.
+4. Use weekly PR cadence to chip away at backlog.


### PR DESCRIPTION
Adds starter forensic backlog log in /99_LOGS/forensic_backfill_log.md.
Tracks initial artifacts requiring Promotion Notices, Chronicle links, or Exchange Blocks.