### PR TITLE
chore/fix migration map pr

### DIFF
--- a/.github/scripts/build_transcripts_index.py
+++ b/.github/scripts/build_transcripts_index.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from datetime import date
+root=Path("99_LOGS/transcripts"); root.mkdir(parents=True, exist_ok=True)
+files=sorted(root.glob("*.txt"), key=lambda p:p.name, reverse=True)
+fm=("""---
+project: Career Intelligence Space
+type: log
+status: matured
+tags: [transcripts, index]
+updated: {today}
+---
+""".format(today=date.today().isoformat()))
+lines=["# Transcripts Index",""]
+lines+=["- [{0}](./{0})".format(p.name) for p in files] if files else ["- _No transcripts yet._"]
+idx=root/"INDEX.md"; idx.write_text(fm+"\n".join(lines)+"\n", encoding="utf-8"); print("wrote",idx)

--- a/.github/workflows/transcripts-ban-md.yml
+++ b/.github/workflows/transcripts-ban-md.yml
@@ -1,0 +1,20 @@
+name: ban-transcripts-md
+on:
+  pull_request:
+    paths:
+      - '99_LOGS/transcripts/**'
+jobs:
+  ban:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if any .md exists under transcripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-files '99_LOGS/transcripts/**/*.md' | grep -q .; then
+            echo "Transcripts must be .txt to avoid linkcheck noise. Found:"
+            git ls-files '99_LOGS/transcripts/**/*.md'
+            exit 1
+          fi
+          echo "OK: no transcript .md files detected."

--- a/.github/workflows/transcripts-index.yml
+++ b/.github/workflows/transcripts-index.yml
@@ -1,0 +1,28 @@
+name: transcripts-index
+on:
+  pull_request:
+    paths:
+      - '99_LOGS/transcripts/**'
+permissions:
+  contents: write
+jobs:
+  build-index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build transcripts index
+        run: python3 .github/scripts/build_transcripts_index.py
+      - name: Commit index if changed
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet -- 99_LOGS/transcripts/INDEX.md; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git add 99_LOGS/transcripts/INDEX.md
+            git commit -m "index: update transcripts index"
+            git push
+          else
+            echo "No index changes."

--- a/.github/workflows/update-migration-map.yml
+++ b/.github/workflows/update-migration-map.yml
@@ -1,0 +1,32 @@
+name: update-migration-map
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 3 * * *'
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Generate migration map
+        run: |
+          set -euo pipefail
+          python3 scripts/build_migration_map.py
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: ci/auto-migration-map
+          title: "docs: auto-update migration map"
+          body: "Automated update of migration map."
+          commit-message: "docs: auto-update migration map [skip ci]"
+          base: main
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Comprehensive career intelligence platform with AI-powered insights for job seek
 
 
 
+

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Comprehensive career intelligence platform with AI-powered insights for job seek
 
 
 
+

--- a/docs/TRANSCRIPTS.md
+++ b/docs/TRANSCRIPTS.md
@@ -1,0 +1,20 @@
+---
+project: Career Intelligence Space
+type: spec
+status: matured
+tags: [transcripts, howto, docs]
+updated: 2025-09-27
+---
+# Transcripts — Upload, Access, Policy
+
+## Upload (one command)
+- Put your export anywhere, then run:
+  - `bin/cis-add-transcript "$HOME/Downloads/<export>.md"`
+
+## Access
+- Browse: `99_LOGS/transcripts/INDEX.md` (auto-updated on PRs touching transcripts).
+- Link from capsules using relative links to the `.txt`.
+
+## Policy
+- Raw transcripts are `.txt` to avoid CI linkcheck noise.
+- Markdown docs (capsules, memos, decisions) stay `.md` and must pass gates.

--- a/scripts/cis_add_transcript.py
+++ b/scripts/cis_add_transcript.py
@@ -1,80 +1,23 @@
-import sys, re, subprocess, os
+import sys,re,subprocess,os
 from pathlib import Path
 from datetime import date
-
-def run(args):
-    return subprocess.run(args, check=True, text=True, capture_output=True).stdout.strip()
-
+def run(a): return subprocess.run(a,check=True,text=True,capture_output=True).stdout.strip()
 def main():
-    if len(sys.argv) < 2:
-        print("usage: cis-add-transcript /path/to/file.md [--tags tag1,tag2]"); sys.exit(2)
-    src = Path(sys.argv[1]).expanduser().resolve()
-    tags = "transcript,field,chat"
-    if len(sys.argv) >= 4 and sys.argv[2] == "--tags": tags = sys.argv[3]
-
-    if not src.exists():
-        print(f"missing: {src}"); sys.exit(1)
-
-    today = date.today().isoformat()
-    safe = re.sub(r'\.md$', '', src.name, flags=re.I)
-    safe = re.sub(r'[^A-Za-z0-9._-]+', '_', safe).strip('_').lower()
-    dst = Path("99_LOGS/transcripts")/f"{today}_{safe}.md"
-    dst.parent.mkdir(parents=True, exist_ok=True)
-
-    txt = src.read_text(encoding="utf-8", errors="ignore").lstrip()
-    fm = f"""---
-project: Career Intelligence Space
-type: log
-status: matured
-tags: [{tags}]
-updated: {today}
----
-"""
-    if not txt.startswith("---"):
-        if txt and not txt.startswith("\n"): txt = "\n"+txt
-        txt = fm + txt
-    dst.write_text(txt, encoding="utf-8")
-    run(["git","add",str(dst)])
-
-    # branch name
-    slug = re.sub(r'[^a-z0-9]+','-', safe).strip('-')
-    branch = f"feat/transcript-{today}-{slug}"
-    try:
-        run(["git","switch","-c",branch])
-    except subprocess.CalledProcessError:
-        run(["git","switch",branch])
-
-    run(["git","commit","-m","log: add field transcript export"])
-    run(["git","push","-u","origin",branch])
-
-    pr_url = run(["gh","pr","create","--fill"])
-    pr_num = run(["gh","pr","view","--json","number","--jq",".number"])
-    try:
-        run(["gh","pr","merge",pr_num,"--squash","--auto"])
-    except subprocess.CalledProcessError:
-        pass
-
-    # retrigger PR-event checks (tiny no-op)
-    Path("README.md").write_text(Path("README.md").read_text(encoding="utf-8") + "\n" if Path("README.md").exists() else "\n", encoding="utf-8")
-    run(["git","add","README.md"])
-    run(["git","commit","-m",f"chore ci retrigger PR checks PR {pr_num}"])
-    run(["git","push"])
-
-    # update-branch (strict protection)
-    try:
-        run(["gh","api","-X","PUT",f"repos/:owner/:repo/pulls/{pr_num}/update-branch","-H","Accept: application/vnd.github+json"])
-    except subprocess.CalledProcessError:
-        pass
-
-    # show health
-    try:
-        out = run(["python3",".github/scripts/pr_health.py",pr_num])
-        print(out)
-    except Exception:
-        pass
-
-    print(f"opened {pr_url}")
-    print(f"target file: {dst}")
-
-if __name__ == "__main__":
-    main()
+    if len(sys.argv)<2: print("usage: cis-add-transcript /path/to/export.(md|txt) [--tags tag1,tag2]"); exit(2)
+    src=Path(sys.argv[1]).expanduser().resolve()
+    if not src.exists(): print(f"missing: {src}"); exit(1)
+    today=date.today().isoformat()
+    safe=re.sub(r'\.(md|txt)$','',src.name,flags=re.I); safe=re.sub(r'[^A-Za-z0-9._-]+','_',safe).strip('_').lower()
+    dst=Path("99_LOGS/transcripts")/f"{today}_{safe}.txt"; dst.parent.mkdir(parents=True,exist_ok=True)
+    dst.write_text(src.read_text(encoding="utf-8",errors="ignore"),encoding="utf-8")
+    slug=re.sub(r'[^a-z0-9]+','-',safe).strip('-'); br=f"feat/transcript-{today}-{slug}"
+    try: run(["git","switch","-c",br])
+    except subprocess.CalledProcessError: run(["git","switch",br])
+    run(["git","add",str(dst)]); run(["git","commit","-m","log add transcript (txt)"]); run(["git","push","-u","origin",br])
+    url=run(["gh","pr","create","--fill"]); num=run(["gh","pr","view","--json","number","--jq",".number"])
+    try: run(["gh","pr","merge",num,"--squash","--auto"])
+    except subprocess.CalledProcessError: pass
+    rd=Path("README.md"); rd.write_text((rd.read_text(encoding="utf-8") if rd.exists() else "")+"\n",encoding="utf-8")
+    run(["git","add","README.md"]); run(["git","commit","-m",f"chore(ci): retrigger PR checks PR {num}"]); run(["git","push"])
+    print(f"opened {url}\ntarget file: {dst}")
+if __name__=="__main__": main()


### PR DESCRIPTION
- **ci: ban .md under 99_LOGS/transcripts (use .txt)**
- **transcripts automation: helper writes .txt, auto-index workflow, docs page**
- **ci: update migration map via PR (no direct push to main)**
