### PR TITLE
fix(ci): Add workflow_dispatch to pr-babysitter for badge updates

### DIFF
--- a/.github/workflows/pr-babysitter.yml
+++ b/.github/workflows/pr-babysitter.yml
@@ -3,6 +3,7 @@ name: PR Babysitter
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
# Fix: PR Babysitter Status Badge

**Issue:** The pr-babysitter workflow status badge shows 'failing' due to historical 0s failures from old branches.

**Root Cause:** 
- Badge reflects the most recent workflow run status
- Recent runs were 0s failures from deleted branches
- No way to manually trigger successful runs to update badge

**Solution:**
- Add `workflow_dispatch` trigger to pr-babysitter workflow
- Allows manual triggering for testing and badge updates
- Maintains existing PR-only functionality

**Benefits:**
- ✅ Can manually trigger successful runs
- ✅ Update status badge to show current health
- ✅ Better debugging and testing capabilities
- ✅ No impact on existing PR functionality

**Testing:**
After merge, will trigger a manual run to update the badge status.