### PR TITLE
fix(workflow): add GH_TOKEN environment variable for GitHub CLI

### DIFF
--- a/.github/workflows/capture-processor.yml
+++ b/.github/workflows/capture-processor.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Create PR for processed captures
         if: steps.check_files.outputs.has_new_files == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Configure git user
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Fixes workflow failure by adding missing GH_TOKEN environment variable for GitHub CLI authentication.