### PR TITLE
chore: set up dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+---
+project: Career Intelligence Space
+type: spec
+status: draft
+tags: [meta, agents]
+updated: 2026-07-16
+---
+
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a documentation / knowledge-management system ("Career
+Intelligence Space"), **not** a long-running web or backend service. The
+"application" is a set of Python CLI tools + shell scripts (in `scripts/` and
+`.github/scripts/`) that lint, validate, and build indexes over the Markdown
+content. There is no dev server to start.
+
+Environment facts (the startup update script already runs `pip install pyyaml
+pytest requests`):
+- Python 3 is used. Only third-party deps are `pyyaml`, `requests`, and
+  `pytest` (test-only). `pyyaml`/`requests` ship with the base image.
+- `yq` (mikefarah) is available at `/usr/bin/yq`; the `Agent CI` workflow uses
+  it to validate `agents/*.yml` and `tasks/*.yml`.
+
+How to test / lint / run (see `.github/workflows/` for the authoritative CI):
+- Tests: `python3 -m pytest -q scripts/tests/test_linter.py` (also
+  `scripts/test_mobile_copilot_capture.py`, `scripts/test_rich_interactions.py`).
+- Frontmatter lint: `python3 scripts/lint_frontmatter.py`. NOTE: this exits
+  non-zero when it finds **stale content** (e.g. `future_spec` docs whose
+  `review_date` is now in the past). That is a content signal, not a broken
+  environment — do not "fix" it as part of setup.
+- Internal link check: `python3 .github/scripts/linkcheck.py` (internal links
+  only, no network needed).
+- Invariants audit: `python3 .github/scripts/invariants_audit.py` (warn-only,
+  always exits 0).
+- Index builders (representative "app" action) write `INDEX.md` files, e.g.
+  `python3 scripts/index/build_intel_index.py` regenerates `intel/INDEX.md`.
+
+Gotchas:
+- Running pytest/scripts creates `__pycache__/` and `.pytest_cache/` which are
+  **not** in `.gitignore`. Do not commit them.
+- The `harness/` submodule (`cis-harness`) is empty/uninitialized here; the
+  tooling above does not require it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Sets up the development environment for the Career Intelligence Space repo and documents it for future agents. This repo is a documentation/knowledge-management system whose "application" is a set of Python CLI tooling + shell scripts (linting, validation, index building) — there is no long-running service.

- Added root `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing deps, how to test/lint/run, and non-obvious gotchas.
- Startup update script (configured separately): `pip install pyyaml pytest requests`.

No application code was modified.

## Type of Change
- [x] Documentation update

## Testing
All run from a clean environment (Python 3.12):

- ✅ `python3 -m pytest -q scripts/tests/test_linter.py scripts/test_mobile_copilot_capture.py scripts/test_rich_interactions.py` — 9 passed
- ✅ `python3 .github/scripts/linkcheck.py` — internal links OK
- ✅ `python3 .github/scripts/invariants_audit.py` — warn-only, exit 0
- ✅ Hello-world: `scripts/index/build_intel_index.py` builds an `INDEX.md` from a new report's frontmatter (run against a temp dir, no repo content changed)
- Note: `python3 scripts/lint_frontmatter.py` runs correctly but exits non-zero on pre-existing stale content (`future_spec` review dates in the past) — a content signal, not an environment issue.

Evidence log: `/opt/cursor/artifacts/env_setup_verification.log`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Future Silo Impact (required if touching /11_FUTURE)
- [x] N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78ea611a-9e59-4fe8-a5c7-a40990dd9c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78ea611a-9e59-4fe8-a5c7-a40990dd9c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

